### PR TITLE
Fix license sync bug

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -1,7 +1,7 @@
 name: Update LicenseDB with latest updates from scancode-toolkit develop daily
 on:
   schedule:
-    - cron: '0 16 * * 0-6'
+    - cron: '0 16 * * 1-5'
   workflow_dispatch:
 
 jobs:
@@ -21,9 +21,6 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Give execute access to the script
-        run: chmod u+x ./etc/scripts/check_commit_run_update.sh
-
       - name: Run script
         run: ./etc/scripts/check_commit_run_update.sh
 
@@ -31,5 +28,6 @@ jobs:
         run: |
           git config --global user.name 'LicenseDB Update GitHub Action'
           git config --global user.email 'asmahapatra@nexb.com'
-          git commit -am "Automated LicenseDB update with latest from scancode-toolkit develop"
+          git add docs/* etc/*
+          git commit -m "Automated LicenseDB update with latest from scancode-toolkit develop"
           git push

--- a/Makefile
+++ b/Makefile
@@ -41,30 +41,15 @@ conf:
 	@venv/bin/pip install -e ./scancode-toolkit/
 	@venv/bin/scancode-reindex-licenses
 
-restore:
+clean:
 	@echo "-> Restoring the repository to a clean state"
 	git clean -fd
 	rm -rf scancode-toolkit/
 	git restore --worktree docs/
 
-clean:
-	# Remove the whole content of docs/ except for the CNAME file
-	# Remove the whole content of scancode-toolkit/
-	find docs/* ! -name 'CNAME' -exec git rm -r {} +
-	find scancode-toolkit/* -exec git rm -r {} +
-
-html:
+licensedb:
 	@echo "-> Generate the HTML content"
 	@venv/bin/scancode-license-data --path docs/
 	@echo "Available at docs/index.html"
 
-build: conf html
-
-publish:
-	@echo "-> Add changes to git"
-	@git add .
-	git commit -m "Upgrade with latest updates from ScanCode-toolkit develop"
-	@echo "-> Push changes to main repo"
-	@git push
-
-.PHONY: conf clean html build publish
+.PHONY: conf clean licensedb

--- a/README.rst
+++ b/README.rst
@@ -85,9 +85,9 @@ Support
 Build
 -----
 
-To re/generate the HTML and API content use this command::
+To re/generate the HTML and API content run the following script::
 
-    $ make restore conf html
+    $ ./etc/scripts/check_commit_run_update.sh
 
 
 License

--- a/etc/scripts/check_commit_run_update.sh
+++ b/etc/scripts/check_commit_run_update.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Clear the repository
-make restore
+make clean
 
 # Create a virtualenv and clone scancode
 make conf
@@ -19,7 +19,7 @@ cd ../
 venv/bin/python ./etc/scripts/check_commit.py --commit "$COMMIT_LATEST"
 
 # build docs
-make html
+make licensedb
 
 # delete cloned scancode as only the doc updates should be commited
 rm -rf scancode-toolkit/


### PR DESCRIPTION
Fixes #32 

Fixed a bug where new license files added at scancode-toolkit were not being added to the LicenseDB website. This was due to using `git commit -am` instead of the regualar `git add .` and then `git commit -m`.

Also made other minor changes and cleanup in the scripts, docs and the github action file.